### PR TITLE
feat: genesis block state update

### DIFF
--- a/src/state/component.cairo
+++ b/src/state/component.cairo
@@ -95,6 +95,10 @@ mod state_cpt {
             // If block number and state root is 0, then we assume it hasn't been initialized yet
             // and the current program output belongs to the genesis block.
             if expected_prev_block_number == 0 && prev_state_root == 0 && prev_block_hash == 0 {
+                // This is the maximum value for a felt252.
+                //
+                // See
+                // https://github.com/starkware-libs/cairo-lang/blob/a86e92bfde9c171c0856d7b46580c66e004922f3/src/starkware/starknet/solidity/StarknetState.sol#L19-L39
                 expected_prev_block_number =
                     0x800000000000011000000000000000000000000000000000000000000000000;
             }

--- a/src/state/component.cairo
+++ b/src/state/component.cairo
@@ -6,6 +6,7 @@
 mod errors {
     const INVALID_BLOCK_NUMBER: felt252 = 'State: invalid block number';
     const INVALID_PREVIOUS_ROOT: felt252 = 'State: invalid previous root';
+    const INVALID_PREVIOUS_BLOCK_NUMBER: felt252 = 'State: invalid prev block num';
 }
 
 /// State component.
@@ -37,6 +38,8 @@ mod state_cpt {
         TContractState, +HasComponent<TContractState>,
     > of IState<ComponentState<TContractState>> {
         fn update(ref self: ComponentState<TContractState>, program_output: StarknetOsOutput) {
+            self.check_prev_block_number(@program_output);
+
             // Check the blockNumber first as the error is less ambiguous then
             // INVALID_PREVIOUS_ROOT.
             self.block_number.write(self.block_number.read() + 1);
@@ -78,6 +81,28 @@ mod state_cpt {
             self.state_root.write(state_root);
             self.block_number.write(block_number);
             self.block_hash.write(block_hash);
+        }
+
+        ///  Validates that the previous block number that appears in the proof is the
+        /// current block number in the state.
+        fn check_prev_block_number(
+            self: @ComponentState<TContractState>, program_output: @StarknetOsOutput
+        ) {
+            let mut expected_prev_block_number: felt252 = self.block_number.read();
+            let prev_state_root: felt252 = self.state_root.read();
+            let prev_block_hash: felt252 = self.block_hash.read();
+
+            // If block number and state root is 0, then we assume it hasn't been initialized yet
+            // and the current program output belongs to the genesis block.
+            if expected_prev_block_number == 0 && prev_state_root == 0 && prev_block_hash == 0 {
+                expected_prev_block_number =
+                    0x800000000000011000000000000000000000000000000000000000000000000;
+            }
+
+            assert(
+                expected_prev_block_number == *program_output.prev_block_number,
+                errors::INVALID_PREVIOUS_BLOCK_NUMBER
+            );
         }
     }
 }

--- a/src/state/tests/test_state.cairo
+++ b/src/state/tests/test_state.cairo
@@ -46,6 +46,34 @@ fn state_update_ok() {
 }
 
 #[test]
+fn genesis_state_update_ok() {
+    let mock = deploy_mock_with_state(state_root: 0, block_number: 0, block_hash: 0,);
+    let os_output = StarknetOsOutput {
+        initial_root: 0,
+        final_root: 1,
+        prev_block_number: 0x800000000000011000000000000000000000000000000000000000000000000,
+        new_block_number: 1,
+        prev_block_hash: 0,
+        new_block_hash: 1,
+        os_program_hash: 1,
+        starknet_os_config_hash: 1,
+        use_kzg_da: 0,
+        full_output: 0,
+        messages_to_l1: array![].span(),
+        messages_to_l2: array![].span(),
+        contracts: array![],
+        classes: array![],
+    };
+    mock.update(os_output);
+
+    let (state_root, block_number, block_hash) = mock.get_state();
+
+    assert(state_root == 1, 'invalid state root');
+    assert(block_number == 1, 'invalid block number');
+    assert(block_hash == 1, 'invalid block hash');
+}
+
+#[test]
 #[should_panic(expected: ('State: invalid block number',))]
 fn state_update_invalid_block_number() {
     let mock = deploy_mock_with_state(state_root: 1, block_number: 1, block_hash: 1,);

--- a/tests/test_appchain.cairo
+++ b/tests/test_appchain.cairo
@@ -32,6 +32,7 @@ fn deploy_with_owner_and_state(
     owner: felt252, state_root: felt252, block_number: felt252, block_hash: felt252,
 ) -> (IAppchainDispatcher, EventSpy) {
     let contract = snf::declare("appchain").unwrap();
+    let block_number: felt252 = block_number.into();
     let calldata = array![owner, state_root, block_number, block_hash];
     let (contract_address, _) = contract.deploy(@calldata).unwrap();
 


### PR DESCRIPTION
Reference implementation: https://github.com/starkware-libs/cairo-lang/blob/a86e92bfde9c171c0856d7b46580c66e004922f3/src/starkware/starknet/solidity/StarknetState.sol#L19-L39

if the current state root, block number, and block hash is 0, then we expect the next state update must be for the genesis block.

the value `0x800000000000011000000000000000000000000000000000000000000000000` is output by `snos` when it is executed for block 0 (ie genesis block)