### PR TITLE
feat: add  patch for MSG magic value

### DIFF
--- a/src/messaging/component.cairo
+++ b/src/messaging/component.cairo
@@ -207,7 +207,7 @@ pub mod messaging_cpt {
             from_address: ContractAddress,
             payload: Span<felt252>,
         ) -> MessageHash {
-            let to_address = starknet::get_caller_address();
+            let to_address = 'MSG'.try_into().unwrap();
 
             let message_hash = hash::compute_message_hash_appc_to_sn(
                 from_address, to_address, payload,


### PR DESCRIPTION
This modification is only a temporary work around for the blockifier limitation, where the `to_address` field for `MsgToL1` is an `EthAddress`.

We will soon have a patch in the dojo blockifier, but in the meantime, this modification allows the correct claim of the messages on Starknet.

The application is already setup to use this value.

This branch is used by Katana to auto-deploy the contract with the magic value.