### PR TITLE
feat(input): add `mock_amd_tee_registry` for e2e tests

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "amd_tee_registry"
 version = "0.1.0"
-source = "git+https://github.com/chudkowsky/katana-tee#11461b5618c1d0393c09f4dc24104f6ee1efc310"
+source = "git+https://github.com/cartridge-gg/katana-tee?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
 
 [[package]]
 name = "integrity"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,7 +7,7 @@ edition = "2024_07"
 starknet = "2.13.1"
 openzeppelin = "0.20.0"
 integrity = "2.0.0"
-amd_tee_registry = { git = "https://github.com/chudkowsky/katana-tee" }
+amd_tee_registry = { git = "https://github.com/cartridge-gg/katana-tee", rev = "56aa752d2e73e505c356c80b7a00eddd27d4d263" }
 
 [dev-dependencies]
 starknet = "2.13.1"

--- a/src/input/component.cairo
+++ b/src/input/component.cairo
@@ -133,12 +133,9 @@ pub trait PiltoverInputTrait {
                 };
                 let commitment = poseidon_hash_span(
                     array![
-                        *tee_input.prev_state_root,
-                        *tee_input.state_root,
-                        *tee_input.prev_block_hash,
-                        *tee_input.block_hash,
-                        *tee_input.prev_block_number,
-                        *tee_input.block_number,
+                        *tee_input.prev_state_root, *tee_input.state_root,
+                        *tee_input.prev_block_hash, *tee_input.block_hash,
+                        *tee_input.prev_block_number, *tee_input.block_number,
                         *tee_input.messages_commitment,
                     ]
                         .span(),
@@ -164,8 +161,7 @@ pub trait PiltoverInputTrait {
                         .append(
                             poseidon_hash_span(
                                 array![
-                                    (*msg.from_address).into(),
-                                    (*msg.to_address).into(),
+                                    (*msg.from_address).into(), (*msg.to_address).into(),
                                     payload_hash,
                                 ]
                                     .span(),

--- a/src/input/mock_amd_tee_registry.cairo
+++ b/src/input/mock_amd_tee_registry.cairo
@@ -1,0 +1,40 @@
+//! Mock implementation of `amd_tee_registry::IAMDTeeRegistry`.
+//!
+//! Used by end-to-end tests that want to exercise Piltover's TEE settlement
+//! path without producing or verifying real AMD SEV-SNP attestations or SP1
+//! Groth16 proofs. In mock mode, the off-chain caller (e.g. `saya-tee
+//! --mock-prove`) builds the `sp1_proof` field of `TEEInput` as the
+//! Cairo-Serde-serialized form of a `VerifierJournal` directly — bypassing
+//! Garaga calldata entirely. This contract simply deserializes that input
+//! back into a `VerifierJournal` and returns it without any cryptographic
+//! checks.
+//!
+//! Piltover's `validate_input` for `TeeInput` only reads `journal.raw_report`
+//! and `journal.result`, so callers can default the rest of the journal
+//! fields. The `raw_report` field must contain a 296-word (1184-byte) buffer
+//! whose `report_data` field at u32 offset 20 encodes
+//! `Poseidon(prev_state_root, state_root, prev_block_hash, block_hash,
+//!           prev_block_number, block_number, messages_commitment)` in the
+//! limb layout that `RawAttestationReport::report_data()` produces.
+
+#[starknet::contract]
+pub mod mock_amd_tee_registry {
+    use amd_tee_registry::tee_registry::IAMDTeeRegistry;
+    use amd_tee_registry::tee_types::VerifierJournal;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl MockImpl of IAMDTeeRegistry<ContractState> {
+        fn verify_sp1_proof(
+            ref self: ContractState, sp1_proof: Array<felt252>,
+        ) -> Result<VerifierJournal, felt252> {
+            let mut span = sp1_proof.span();
+            match Serde::<VerifierJournal>::deserialize(ref span) {
+                Option::Some(journal) => Result::Ok(journal),
+                Option::None => Result::Err('mock: deserialize failed'),
+            }
+        }
+    }
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -4,6 +4,7 @@ pub mod interface;
 pub mod input {
     pub mod component;
     pub mod layout_bridge;
+    pub mod mock_amd_tee_registry;
     pub mod snos_output;
     pub mod tee_input;
 }

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -1,3 +1,4 @@
 //! Testing module.
 //!
 mod test_appchain;
+mod test_mock_amd_tee_registry;

--- a/tests/test_mock_amd_tee_registry.cairo
+++ b/tests/test_mock_amd_tee_registry.cairo
@@ -1,0 +1,75 @@
+//! Tests for `piltover::input::mock_amd_tee_registry`.
+//!
+//! Verifies that the mock contract round-trips a `VerifierJournal` through
+//! its `verify_sp1_proof` entry point: a journal serialized via Cairo Serde
+//! into the `sp1_proof: Array<felt252>` argument is returned bit-for-bit
+//! intact, with no on-chain verification of the underlying SP1 Groth16 proof
+//! or AMD attestation report.
+
+use amd_tee_registry::tee_registry::{
+    IAMDTeeRegistryDispatcher, IAMDTeeRegistryDispatcherTrait,
+};
+use amd_tee_registry::tee_types::{VerificationResult, VerifierJournal};
+use snforge_std as snf;
+use snforge_std::ContractClassTrait;
+use starknet::SyscallResultTrait;
+
+/// Deploys the mock AMD TEE registry contract and returns a dispatcher.
+fn deploy_mock_amd_tee_registry() -> IAMDTeeRegistryDispatcher {
+    let contract = match snf::declare("mock_amd_tee_registry").unwrap_syscall() {
+        snf::DeclareResult::Success(contract) => contract,
+        _ => core::panic_with_felt252('AlreadyDeclared not expected'),
+    };
+    let (contract_address, _) = contract.deploy(@array![]).unwrap_syscall();
+    IAMDTeeRegistryDispatcher { contract_address }
+}
+
+/// Builds a `VerifierJournal` whose `raw_report` field has the canonical
+/// 296-word (1184-byte) length expected by `RawAttestationReport`. All
+/// fields are filled with deterministic, recognisable values so the
+/// round-trip assertion below is meaningful.
+fn make_journal() -> VerifierJournal {
+    let mut raw_report: Array<u32> = array![];
+    let mut i: u32 = 0;
+    while i < 296 {
+        raw_report.append(i);
+        i += 1;
+    }
+
+    VerifierJournal {
+        result: VerificationResult::Success,
+        timestamp: 1_700_000_000,
+        processor_model: 0,
+        raw_report: raw_report.span(),
+        certs: array![],
+        cert_serials: array![],
+        trusted_certs_prefix_len: 1,
+        storage_commitment: 0,
+        fork_block_number: 0,
+        end_block_number: 0,
+    }
+}
+
+#[test]
+fn test_mock_round_trips_journal() {
+    let registry = deploy_mock_amd_tee_registry();
+    let journal_in = make_journal();
+
+    let mut sp1_proof: Array<felt252> = array![];
+    Serde::<VerifierJournal>::serialize(@journal_in, ref sp1_proof);
+
+    let journal_out = registry.verify_sp1_proof(sp1_proof).expect('verify_sp1_proof failed');
+
+    assert!(journal_out == journal_in, "round-tripped journal does not match input");
+}
+
+#[test]
+fn test_mock_rejects_garbage() {
+    let registry = deploy_mock_amd_tee_registry();
+    // A short felt array that cannot deserialize into a VerifierJournal.
+    let sp1_proof: Array<felt252> = array![1, 2, 3];
+    match registry.verify_sp1_proof(sp1_proof) {
+        Result::Ok(_) => core::panic_with_felt252('expected error'),
+        Result::Err(e) => assert!(e == 'mock: deserialize failed', "wrong error: {}", e),
+    }
+}

--- a/tests/test_mock_amd_tee_registry.cairo
+++ b/tests/test_mock_amd_tee_registry.cairo
@@ -6,9 +6,7 @@
 //! intact, with no on-chain verification of the underlying SP1 Groth16 proof
 //! or AMD attestation report.
 
-use amd_tee_registry::tee_registry::{
-    IAMDTeeRegistryDispatcher, IAMDTeeRegistryDispatcherTrait,
-};
+use amd_tee_registry::tee_registry::{IAMDTeeRegistryDispatcher, IAMDTeeRegistryDispatcherTrait};
 use amd_tee_registry::tee_types::{VerificationResult, VerifierJournal};
 use snforge_std as snf;
 use snforge_std::ContractClassTrait;


### PR DESCRIPTION
## Summary

- Adds `piltover::input::mock_amd_tee_registry` — a mock implementation of `amd_tee_registry::IAMDTeeRegistry` that bypasses on-chain Groth16 verification of SP1 attestation proofs and just round-trips a `VerifierJournal` through Cairo Serde.
- Fixes the `amd_tee_registry` Scarb dep to point at canonical `cartridge-gg/katana-tee` (was pointing at `chudkowsky/katana-tee` personal fork) and pins it to rev `56aa752d` to match `dojoengine/saya`'s pin.

## Why

End-to-end tests for `saya-tee` (the persistent-TEE Saya prover) want to exercise Piltover's TEE settlement path without producing or verifying real AMD SEV-SNP attestations or burning SP1 prover network credits. The mock unblocks that by making it possible to deploy a permissive registry contract via `saya-ops`, point Piltover at it through the existing `setup-program --fact-registry-address` flow, and have a paired `saya-tee --mock-prove` flag (separate PR) emit `TEEInput.sp1_proof` as a Serde-serialized journal that this contract decodes verbatim.

This follows the same pattern as the existing `fact_registry_mock` for the Integrity-based persistent mode.

## What does NOT change

- `piltover::input::component::validate_input` is untouched. Piltover dispatches via `IAMDTeeRegistryDispatcher`, so swapping in the mock at the `fact_registry_address` config slot is sufficient — no validate_input branching.
- The downstream assertions in `validate_input` (Poseidon commitment over state roots, `messages_commitment` reconstruction, etc.) all run unchanged.

## Test plan

- [x] `scarb build` clean (sierra + casm artifacts produced for `piltover_mock_amd_tee_registry`).
- [x] `scarb test` — 54 tests pass (53 pre-existing + 2 new).
- [x] New `tests/test_mock_amd_tee_registry.cairo` covers Serde round-trip and a negative-path garbage-input case.

## Companion PRs (in flight)

- `dojoengine/saya`: `feat: --mock-prove flag in bin/persistent-tee`
- `dojoengine/saya`: `feat(ops): declare-and-deploy-tee-registry-mock`
- `dojoengine/katana`: `test(saya): saya-tee e2e test crate`


## Downstream consumer note

The compiled Sierra class produced from this contract
(`target/dev/piltover_mock_amd_tee_registry.contract_class.json`) is
vendored into `dojoengine/saya` at `contracts/tee_registry_mock.json`
and embedded into the `saya-ops` binary via `include_bytes!`. See
[dojoengine/saya#60](https://github.com/dojoengine/saya/pull/60) for
the consumer side.

If this contract changes after merge, the vendored artifact in saya
must be rebuilt and re-copied. The procedure is documented in the
"Maintaining the embedded mock TEE registry artifact" section of
saya#60. The class hash will change with the source, but no caller
needs to be updated — `saya-ops core-contract
declare-and-deploy-tee-registry-mock` re-declares the class on every
invocation.
