### PR TITLE
feat(input): bind TEE attestation to versioned environment config hash

### DIFF
--- a/piltover/src/bindgen.rs
+++ b/piltover/src/bindgen.rs
@@ -103,6 +103,40 @@ impl cainome::cairo_serde::CairoSerde for DaLayerInfo {
     }
 }
 #[derive()]
+pub struct KatanaTeeProgramInfo {
+    pub katana_tee_config_hash: starknet::core::types::Felt,
+}
+impl cainome::cairo_serde::CairoSerde for KatanaTeeProgramInfo {
+    type RustType = Self;
+    const SERIALIZED_SIZE: std::option::Option<usize> = None;
+    #[inline]
+    fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
+        let mut __size = 0;
+        __size +=
+            starknet::core::types::Felt::cairo_serialized_size(&__rust.katana_tee_config_hash);
+        __size
+    }
+    fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
+        let mut __out: Vec<starknet::core::types::Felt> = vec![];
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.katana_tee_config_hash,
+        ));
+        __out
+    }
+    fn cairo_deserialize(
+        __felts: &[starknet::core::types::Felt],
+        __offset: usize,
+    ) -> cainome::cairo_serde::Result<Self::RustType> {
+        let mut __offset = __offset;
+        let katana_tee_config_hash =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&katana_tee_config_hash);
+        Ok(KatanaTeeProgramInfo {
+            katana_tee_config_hash,
+        })
+    }
+}
+#[derive()]
 pub struct LogStateTransitionFact {
     pub state_transition_fact: cainome::cairo_serde::U256,
 }
@@ -939,66 +973,6 @@ impl OwnershipTransferred {
     }
 }
 #[derive()]
-pub struct ProgramInfo {
-    pub bootloader_program_hash: starknet::core::types::Felt,
-    pub snos_config_hash: starknet::core::types::Felt,
-    pub snos_program_hash: starknet::core::types::Felt,
-    pub layout_bridge_program_hash: starknet::core::types::Felt,
-}
-impl cainome::cairo_serde::CairoSerde for ProgramInfo {
-    type RustType = Self;
-    const SERIALIZED_SIZE: std::option::Option<usize> = None;
-    #[inline]
-    fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
-        let mut __size = 0;
-        __size +=
-            starknet::core::types::Felt::cairo_serialized_size(&__rust.bootloader_program_hash);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.snos_config_hash);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.snos_program_hash);
-        __size +=
-            starknet::core::types::Felt::cairo_serialized_size(&__rust.layout_bridge_program_hash);
-        __size
-    }
-    fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
-        let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.bootloader_program_hash,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.snos_config_hash,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.snos_program_hash,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.layout_bridge_program_hash,
-        ));
-        __out
-    }
-    fn cairo_deserialize(
-        __felts: &[starknet::core::types::Felt],
-        __offset: usize,
-    ) -> cainome::cairo_serde::Result<Self::RustType> {
-        let mut __offset = __offset;
-        let bootloader_program_hash =
-            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&bootloader_program_hash);
-        let snos_config_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&snos_config_hash);
-        let snos_program_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&snos_program_hash);
-        let layout_bridge_program_hash =
-            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&layout_bridge_program_hash);
-        Ok(ProgramInfo {
-            bootloader_program_hash,
-            snos_config_hash,
-            snos_program_hash,
-            layout_bridge_program_hash,
-        })
-    }
-}
-#[derive()]
 pub struct ProgramInfoChanged {
     pub changed_by: cainome::cairo_serde::ContractAddress,
     pub old_program_info: ProgramInfo,
@@ -1052,6 +1026,66 @@ impl ProgramInfoChanged {
     }
 }
 #[derive()]
+pub struct StarknetOsProgramInfo {
+    pub bootloader_program_hash: starknet::core::types::Felt,
+    pub snos_config_hash: starknet::core::types::Felt,
+    pub snos_program_hash: starknet::core::types::Felt,
+    pub layout_bridge_program_hash: starknet::core::types::Felt,
+}
+impl cainome::cairo_serde::CairoSerde for StarknetOsProgramInfo {
+    type RustType = Self;
+    const SERIALIZED_SIZE: std::option::Option<usize> = None;
+    #[inline]
+    fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
+        let mut __size = 0;
+        __size +=
+            starknet::core::types::Felt::cairo_serialized_size(&__rust.bootloader_program_hash);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.snos_config_hash);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.snos_program_hash);
+        __size +=
+            starknet::core::types::Felt::cairo_serialized_size(&__rust.layout_bridge_program_hash);
+        __size
+    }
+    fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
+        let mut __out: Vec<starknet::core::types::Felt> = vec![];
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.bootloader_program_hash,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.snos_config_hash,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.snos_program_hash,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.layout_bridge_program_hash,
+        ));
+        __out
+    }
+    fn cairo_deserialize(
+        __felts: &[starknet::core::types::Felt],
+        __offset: usize,
+    ) -> cainome::cairo_serde::Result<Self::RustType> {
+        let mut __offset = __offset;
+        let bootloader_program_hash =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&bootloader_program_hash);
+        let snos_config_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&snos_config_hash);
+        let snos_program_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&snos_program_hash);
+        let layout_bridge_program_hash =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&layout_bridge_program_hash);
+        Ok(StarknetOsProgramInfo {
+            bootloader_program_hash,
+            snos_config_hash,
+            snos_program_hash,
+            layout_bridge_program_hash,
+        })
+    }
+}
+#[derive()]
 pub struct TEEInput {
     pub sp1_proof: Vec<starknet::core::types::Felt>,
     pub prev_state_root: starknet::core::types::Felt,
@@ -1064,6 +1098,7 @@ pub struct TEEInput {
     pub messages_to_starknet: Vec<MessageToStarknet>,
     pub messages_to_appchain: Vec<MessageToAppchain>,
     pub l1_to_l2_msg_hashes: Vec<starknet::core::types::Felt>,
+    pub katana_tee_config_hash: starknet::core::types::Felt,
 }
 impl cainome::cairo_serde::CairoSerde for TEEInput {
     type RustType = Self;
@@ -1083,6 +1118,8 @@ impl cainome::cairo_serde::CairoSerde for TEEInput {
         __size += Vec::<MessageToAppchain>::cairo_serialized_size(&__rust.messages_to_appchain);
         __size +=
             Vec::<starknet::core::types::Felt>::cairo_serialized_size(&__rust.l1_to_l2_msg_hashes);
+        __size +=
+            starknet::core::types::Felt::cairo_serialized_size(&__rust.katana_tee_config_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
@@ -1120,6 +1157,9 @@ impl cainome::cairo_serde::CairoSerde for TEEInput {
         __out.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
             &__rust.l1_to_l2_msg_hashes,
         ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.katana_tee_config_hash,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -1151,6 +1191,9 @@ impl cainome::cairo_serde::CairoSerde for TEEInput {
         let l1_to_l2_msg_hashes =
             Vec::<starknet::core::types::Felt>::cairo_deserialize(__felts, __offset)?;
         __offset += Vec::<starknet::core::types::Felt>::cairo_serialized_size(&l1_to_l2_msg_hashes);
+        let katana_tee_config_hash =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&katana_tee_config_hash);
         Ok(TEEInput {
             sp1_proof,
             prev_state_root,
@@ -1163,6 +1206,7 @@ impl cainome::cairo_serde::CairoSerde for TEEInput {
             messages_to_starknet,
             messages_to_appchain,
             l1_to_l2_msg_hashes,
+            katana_tee_config_hash,
         })
     }
 }
@@ -4674,6 +4718,61 @@ impl cainome::cairo_serde::CairoSerde for PiltoverInput {
                 return Err(cainome::cairo_serde::Error::Deserialize(format!(
                     "Index not handle for enum {}",
                     "PiltoverInput"
+                )))
+            }
+        }
+    }
+}
+#[derive()]
+pub enum ProgramInfo {
+    StarknetOs(StarknetOsProgramInfo),
+    KatanaTee(KatanaTeeProgramInfo),
+}
+impl cainome::cairo_serde::CairoSerde for ProgramInfo {
+    type RustType = Self;
+    const SERIALIZED_SIZE: std::option::Option<usize> = std::option::Option::None;
+    #[inline]
+    fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
+        match __rust {
+            ProgramInfo::StarknetOs(val) => StarknetOsProgramInfo::cairo_serialized_size(val) + 1,
+            ProgramInfo::KatanaTee(val) => KatanaTeeProgramInfo::cairo_serialized_size(val) + 1,
+            _ => 0,
+        }
+    }
+    fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
+        match __rust {
+            ProgramInfo::StarknetOs(val) => {
+                let mut temp = vec![];
+                temp.extend(usize::cairo_serialize(&0usize));
+                temp.extend(StarknetOsProgramInfo::cairo_serialize(val));
+                temp
+            }
+            ProgramInfo::KatanaTee(val) => {
+                let mut temp = vec![];
+                temp.extend(usize::cairo_serialize(&1usize));
+                temp.extend(KatanaTeeProgramInfo::cairo_serialize(val));
+                temp
+            }
+            _ => vec![],
+        }
+    }
+    fn cairo_deserialize(
+        __felts: &[starknet::core::types::Felt],
+        __offset: usize,
+    ) -> cainome::cairo_serde::Result<Self::RustType> {
+        let __f = __felts[__offset];
+        let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
+        match __index as usize {
+            0usize => Ok(ProgramInfo::StarknetOs(
+                StarknetOsProgramInfo::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            1usize => Ok(ProgramInfo::KatanaTee(
+                KatanaTeeProgramInfo::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            _ => {
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "ProgramInfo"
                 )))
             }
         }

--- a/src/appchain.cairo
+++ b/src/appchain.cairo
@@ -144,7 +144,7 @@ pub mod appchain {
 
             let program_info = self.config.program_info.read();
             let expected_katana_tee_config_hash = compute_katana_tee_config_hash(
-                self.config.get_chain_id(), self.config.get_fee_token_address(),
+                program_info.chain_id, program_info.fee_token_address,
             );
 
             assert!(

--- a/src/appchain.cairo
+++ b/src/appchain.cairo
@@ -27,7 +27,6 @@ pub mod appchain {
     use starknet::storage::StoragePointerReadAccess;
     use starknet::{ClassHash, ContractAddress};
     use crate::input::component::{PiltoverInput, PiltoverInputTrait};
-    use crate::input::katana_tee_config::compute_katana_tee_config_hash;
 
     /// The default cancellation delay of 5 days.
     const CANCELLATION_DELAY_SECS: u64 = 432000;
@@ -143,17 +142,9 @@ pub mod appchain {
             self.config.assert_only_owner_or_operator();
 
             let program_info = self.config.program_info.read();
-            let expected_katana_tee_config_hash = compute_katana_tee_config_hash(
-                program_info.chain_id, program_info.fee_token_address,
-            );
 
             assert!(
-                piltover_input
-                    .validate_input(
-                        program_info,
-                        self.config.get_facts_registry(),
-                        expected_katana_tee_config_hash,
-                    ),
+                piltover_input.validate_input(program_info, self.config.get_facts_registry()),
                 "Input validation failed",
             );
 

--- a/src/appchain.cairo
+++ b/src/appchain.cairo
@@ -27,6 +27,7 @@ pub mod appchain {
     use starknet::storage::StoragePointerReadAccess;
     use starknet::{ClassHash, ContractAddress};
     use crate::input::component::{PiltoverInput, PiltoverInputTrait};
+    use crate::input::katana_tee_config::compute_katana_tee_config_hash;
 
     /// The default cancellation delay of 5 days.
     const CANCELLATION_DELAY_SECS: u64 = 432000;
@@ -142,9 +143,17 @@ pub mod appchain {
             self.config.assert_only_owner_or_operator();
 
             let program_info = self.config.program_info.read();
+            let expected_katana_tee_config_hash = compute_katana_tee_config_hash(
+                self.config.get_chain_id(), self.config.get_fee_token_address(),
+            );
 
             assert!(
-                piltover_input.validate_input(program_info, self.config.get_facts_registry()),
+                piltover_input
+                    .validate_input(
+                        program_info,
+                        self.config.get_facts_registry(),
+                        expected_katana_tee_config_hash,
+                    ),
                 "Input validation failed",
             );
 

--- a/src/config/component.cairo
+++ b/src/config/component.cairo
@@ -36,6 +36,11 @@ pub mod config_cpt {
         pub facts_registry: ContractAddress,
         /// Is KZG DA enabled.
         pub use_kzg_da: bool,
+        /// Appchain chain id; one input to the Katana TEE config hash.
+        pub chain_id: felt252,
+        /// Appchain non-legacy (STRK) fee token address; one input to the
+        /// Katana TEE config hash.
+        pub fee_token_address: ContractAddress,
     }
 
     #[event]
@@ -107,6 +112,26 @@ pub mod config_cpt {
 
         fn get_use_kzg_da(self: @ComponentState<TContractState>) -> bool {
             self.use_kzg_da.read()
+        }
+
+        fn set_chain_id(ref self: ComponentState<TContractState>, chain_id: felt252) {
+            self.assert_only_owner_or_operator();
+            self.chain_id.write(chain_id);
+        }
+
+        fn get_chain_id(self: @ComponentState<TContractState>) -> felt252 {
+            self.chain_id.read()
+        }
+
+        fn set_fee_token_address(
+            ref self: ComponentState<TContractState>, fee_token_address: ContractAddress,
+        ) {
+            self.assert_only_owner_or_operator();
+            self.fee_token_address.write(fee_token_address);
+        }
+
+        fn get_fee_token_address(self: @ComponentState<TContractState>) -> ContractAddress {
+            self.fee_token_address.read()
         }
     }
 

--- a/src/config/component.cairo
+++ b/src/config/component.cairo
@@ -31,16 +31,13 @@ pub mod config_cpt {
         /// Appchain operators that are allowed to update the state.
         pub operators: Map<ContractAddress, bool>,
         /// The information of the program verified to apply the state transition.
+        /// Also carries the chain id and STRK fee token address that feed the v1
+        /// Katana TEE config hash.
         pub program_info: ProgramInfo,
         /// Facts registry contract address.
         pub facts_registry: ContractAddress,
         /// Is KZG DA enabled.
         pub use_kzg_da: bool,
-        /// Appchain chain id; one input to the Katana TEE config hash.
-        pub chain_id: felt252,
-        /// Appchain non-legacy (STRK) fee token address; one input to the
-        /// Katana TEE config hash.
-        pub fee_token_address: ContractAddress,
     }
 
     #[event]
@@ -112,26 +109,6 @@ pub mod config_cpt {
 
         fn get_use_kzg_da(self: @ComponentState<TContractState>) -> bool {
             self.use_kzg_da.read()
-        }
-
-        fn set_chain_id(ref self: ComponentState<TContractState>, chain_id: felt252) {
-            self.assert_only_owner_or_operator();
-            self.chain_id.write(chain_id);
-        }
-
-        fn get_chain_id(self: @ComponentState<TContractState>) -> felt252 {
-            self.chain_id.read()
-        }
-
-        fn set_fee_token_address(
-            ref self: ComponentState<TContractState>, fee_token_address: ContractAddress,
-        ) {
-            self.assert_only_owner_or_operator();
-            self.fee_token_address.write(fee_token_address);
-        }
-
-        fn get_fee_token_address(self: @ComponentState<TContractState>) -> ContractAddress {
-            self.fee_token_address.read()
         }
     }
 

--- a/src/config/interface.cairo
+++ b/src/config/interface.cairo
@@ -25,6 +25,13 @@ pub struct ProgramInfo {
     pub snos_program_hash: felt252,
     /// The hash of the Layout Bridge program.
     pub layout_bridge_program_hash: felt252,
+    /// The appchain chain id. One input to the v1 Katana TEE config hash;
+    /// must match the chain spec the Katana node runs against.
+    pub chain_id: felt252,
+    /// The appchain non-legacy (STRK) fee token address. The other input to
+    /// the v1 Katana TEE config hash; must match the fee token deployed on
+    /// the appchain.
+    pub fee_token_address: ContractAddress,
 }
 
 #[starknet::interface]
@@ -96,20 +103,4 @@ pub trait IConfig<T> {
     ///
     /// Whether KZG DA is enabled.
     fn get_use_kzg_da(self: @T) -> bool;
-
-    /// Sets the appchain chain id used to compute the Katana TEE config hash
-    /// bound into v1 attestations. Must match the chain spec the Katana node
-    /// runs against, otherwise TEE attestations will be rejected.
-    fn set_chain_id(ref self: T, chain_id: felt252);
-
-    /// Gets the appchain chain id.
-    fn get_chain_id(self: @T) -> felt252;
-
-    /// Sets the appchain fee token address (STRK / non-legacy fee token) used
-    /// to compute the Katana TEE config hash. Must match the fee token deployed
-    /// on the appchain.
-    fn set_fee_token_address(ref self: T, fee_token_address: ContractAddress);
-
-    /// Gets the appchain fee token address.
-    fn get_fee_token_address(self: @T) -> ContractAddress;
 }

--- a/src/config/interface.cairo
+++ b/src/config/interface.cairo
@@ -96,4 +96,20 @@ pub trait IConfig<T> {
     ///
     /// Whether KZG DA is enabled.
     fn get_use_kzg_da(self: @T) -> bool;
+
+    /// Sets the appchain chain id used to compute the Katana TEE config hash
+    /// bound into v1 attestations. Must match the chain spec the Katana node
+    /// runs against, otherwise TEE attestations will be rejected.
+    fn set_chain_id(ref self: T, chain_id: felt252);
+
+    /// Gets the appchain chain id.
+    fn get_chain_id(self: @T) -> felt252;
+
+    /// Sets the appchain fee token address (STRK / non-legacy fee token) used
+    /// to compute the Katana TEE config hash. Must match the fee token deployed
+    /// on the appchain.
+    fn set_fee_token_address(ref self: T, fee_token_address: ContractAddress);
+
+    /// Gets the appchain fee token address.
+    fn get_fee_token_address(self: @T) -> ContractAddress;
 }

--- a/src/config/interface.cairo
+++ b/src/config/interface.cairo
@@ -3,19 +3,18 @@
 //! Interface for appchain settlement contract configuration.
 use starknet::ContractAddress;
 
-/// Information of the program verified onchain to apply the state transition.
+/// Program info for validity-proof (StarknetOS + Layout Bridge) settlement.
 ///
-/// In the current design, the StarknetOS (SNOS) is executed and proven first.
-/// Since the layout used by SNOS is not verifiable onchain, a bridge layout
-/// program is also executed on the proof generated from SNOS execution.
+/// The StarknetOS (SNOS) is executed and proven first. Since the layout used by
+/// SNOS is not verifiable onchain, a bridge layout program is also executed on
+/// the proof generated from SNOS execution. Since the Layout Bridge program is
+/// bootloaded, the bootloader program hash is also included, as the fact
+/// registered in the facts registry is computed from the Layout Bridge program
+/// hash and its output.
 ///
-/// Since the Layout Bridge program is bootloaded, the bootloader program hash
-/// is also included in the program info, as the fact registered in the
-/// facts registry is computed from the Layout Bridge program hash and its output.
-///
-/// This ensures that the correct programs have been executed.
+/// The four hashes together pin the SNOS execution environment.
 #[derive(starknet::Store, Drop, Serde, Copy, PartialEq)]
-pub struct ProgramInfo {
+pub struct StarknetOsProgramInfo {
     /// The hash of the bootloader program that bootloads the Layout Bridge program.
     pub bootloader_program_hash: felt252,
     /// The hash of the SNOS config:
@@ -25,13 +24,37 @@ pub struct ProgramInfo {
     pub snos_program_hash: felt252,
     /// The hash of the Layout Bridge program.
     pub layout_bridge_program_hash: felt252,
-    /// The appchain chain id. One input to the v1 Katana TEE config hash;
-    /// must match the chain spec the Katana node runs against.
-    pub chain_id: felt252,
-    /// The appchain non-legacy (STRK) fee token address. The other input to
-    /// the v1 Katana TEE config hash; must match the fee token deployed on
-    /// the appchain.
-    pub fee_token_address: ContractAddress,
+}
+
+/// Program info for Katana TEE settlement.
+///
+/// In TEE mode, the appchain is identified entirely by a single versioned
+/// environment config hash bound into the SEV-SNP `report_data`. Program hashes
+/// are irrelevant; the TEE attestation pins the off-chain Katana node, not a
+/// Cairo program.
+#[derive(starknet::Store, Drop, Serde, Copy, PartialEq)]
+pub struct KatanaTeeProgramInfo {
+    /// Versioned environment config hash bound into v1 TEE attestations.
+    /// Computed off-chain by the Katana node:
+    /// `pedersen_array([KatanaTeeConfig1, chain_id, fee_token_address])`.
+    /// The on-chain side stores it and compares against the attested value;
+    /// it does not recompute.
+    pub katana_tee_config_hash: felt252,
+}
+
+/// Information of the program verified onchain to apply the state transition.
+///
+/// Each Piltover deployment commits to one settlement mode at config time. The
+/// `PiltoverInput` variant submitted to `update_state` must agree with the
+/// active `ProgramInfo` variant or the call panics.
+#[derive(starknet::Store, Drop, Serde, Copy, PartialEq)]
+pub enum ProgramInfo {
+    /// Default variant: an all-zero `StarknetOsProgramInfo` is what fresh storage
+    /// returns before `set_program_info` is called. This preserves the original
+    /// semantics from when `ProgramInfo` was a single struct of zeroed felts.
+    #[default]
+    StarknetOs: StarknetOsProgramInfo,
+    KatanaTee: KatanaTeeProgramInfo,
 }
 
 #[starknet::interface]

--- a/src/config/tests/test_config.cairo
+++ b/src/config/tests/test_config.cairo
@@ -1,5 +1,8 @@
 use piltover::config::tests::constants as c;
-use piltover::config::{IConfigDispatcher, IConfigDispatcherTrait, ProgramInfo};
+use piltover::config::{
+    IConfigDispatcher, IConfigDispatcherTrait, KatanaTeeProgramInfo, ProgramInfo,
+    StarknetOsProgramInfo,
+};
 use snforge_std as snf;
 use snforge_std::ContractClassTrait;
 
@@ -87,14 +90,14 @@ fn config_set_program_info_ok() {
     snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
 
     // Owner sets the info.
-    let program_info = ProgramInfo {
-        bootloader_program_hash: 0x1,
-        snos_config_hash: 0x2,
-        snos_program_hash: 0x3,
-        layout_bridge_program_hash: 0x4,
-        chain_id: 'KATANA',
-        fee_token_address: 0xfee.try_into().unwrap(),
-    };
+    let program_info = ProgramInfo::StarknetOs(
+        StarknetOsProgramInfo {
+            bootloader_program_hash: 0x1,
+            snos_config_hash: 0x2,
+            snos_program_hash: 0x3,
+            layout_bridge_program_hash: 0x4,
+        },
+    );
     mock.set_program_info(program_info);
     assert(mock.get_program_info() == program_info, 'expect correct hashes');
 
@@ -102,17 +105,30 @@ fn config_set_program_info_ok() {
 
     // Operator can also set the program info.
     snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
-    let program_info = ProgramInfo {
-        bootloader_program_hash: 0x11,
-        snos_config_hash: 0x22,
-        snos_program_hash: 0x33,
-        layout_bridge_program_hash: 0x44,
-        chain_id: 'SN_SEPOLIA',
-        fee_token_address: 0xfee2.try_into().unwrap(),
-    };
+    let program_info = ProgramInfo::StarknetOs(
+        StarknetOsProgramInfo {
+            bootloader_program_hash: 0x11,
+            snos_config_hash: 0x22,
+            snos_program_hash: 0x33,
+            layout_bridge_program_hash: 0x44,
+        },
+    );
     mock.set_program_info(program_info);
 
     assert(mock.get_program_info() == program_info, 'expect operator hashes');
+}
+
+#[test]
+fn config_set_program_info_katana_tee_variant_ok() {
+    let mock = deploy_mock();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+
+    let program_info = ProgramInfo::KatanaTee(
+        KatanaTeeProgramInfo { katana_tee_config_hash: 0xabc },
+    );
+    mock.set_program_info(program_info);
+    assert(mock.get_program_info() == program_info, 'expect tee variant roundtrip');
 }
 
 #[test]
@@ -123,14 +139,14 @@ fn config_set_program_info_unauthorized() {
     snf::start_cheat_caller_address(mock.contract_address, c::OPERATOR);
     mock
         .set_program_info(
-            ProgramInfo {
-                bootloader_program_hash: 0x1,
-                snos_config_hash: 0x2,
-                snos_program_hash: 0x3,
-                layout_bridge_program_hash: 0x4,
-                chain_id: 'KATANA',
-                fee_token_address: 0xfee.try_into().unwrap(),
-            },
+            ProgramInfo::StarknetOs(
+                StarknetOsProgramInfo {
+                    bootloader_program_hash: 0x1,
+                    snos_config_hash: 0x2,
+                    snos_program_hash: 0x3,
+                    layout_bridge_program_hash: 0x4,
+                },
+            ),
         );
 }
 

--- a/src/config/tests/test_config.cairo
+++ b/src/config/tests/test_config.cairo
@@ -92,6 +92,8 @@ fn config_set_program_info_ok() {
         snos_config_hash: 0x2,
         snos_program_hash: 0x3,
         layout_bridge_program_hash: 0x4,
+        chain_id: 'KATANA',
+        fee_token_address: 0xfee.try_into().unwrap(),
     };
     mock.set_program_info(program_info);
     assert(mock.get_program_info() == program_info, 'expect correct hashes');
@@ -105,6 +107,8 @@ fn config_set_program_info_ok() {
         snos_config_hash: 0x22,
         snos_program_hash: 0x33,
         layout_bridge_program_hash: 0x44,
+        chain_id: 'SN_SEPOLIA',
+        fee_token_address: 0xfee2.try_into().unwrap(),
     };
     mock.set_program_info(program_info);
 
@@ -124,6 +128,8 @@ fn config_set_program_info_unauthorized() {
                 snos_config_hash: 0x2,
                 snos_program_hash: 0x3,
                 layout_bridge_program_hash: 0x4,
+                chain_id: 'KATANA',
+                fee_token_address: 0xfee.try_into().unwrap(),
             },
         );
 }
@@ -159,44 +165,4 @@ fn config_set_facts_registry_unauthorized() {
     // Other is not an operator.
     snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
     mock.set_facts_registry(facts_registry_address);
-}
-
-#[test]
-fn config_set_chain_id_ok() {
-    let mock = deploy_mock();
-
-    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
-    assert(mock.get_chain_id() == 0, 'expect default 0');
-
-    mock.set_chain_id('KATANA');
-    assert(mock.get_chain_id() == 'KATANA', 'expect chain id set');
-}
-
-#[test]
-#[should_panic(expected: ('Config: not owner or operator',))]
-fn config_set_chain_id_unauthorized() {
-    let mock = deploy_mock();
-    snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
-    mock.set_chain_id('KATANA');
-}
-
-#[test]
-fn config_set_fee_token_address_ok() {
-    let mock = deploy_mock();
-    let fee_token: starknet::ContractAddress = '0xabc'.try_into().unwrap();
-
-    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
-    assert(mock.get_fee_token_address() == 0.try_into().unwrap(), 'expect default 0');
-
-    mock.set_fee_token_address(fee_token);
-    assert(mock.get_fee_token_address() == fee_token, 'expect fee token set');
-}
-
-#[test]
-#[should_panic(expected: ('Config: not owner or operator',))]
-fn config_set_fee_token_address_unauthorized() {
-    let mock = deploy_mock();
-    let fee_token: starknet::ContractAddress = '0xabc'.try_into().unwrap();
-    snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
-    mock.set_fee_token_address(fee_token);
 }

--- a/src/config/tests/test_config.cairo
+++ b/src/config/tests/test_config.cairo
@@ -160,3 +160,43 @@ fn config_set_facts_registry_unauthorized() {
     snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
     mock.set_facts_registry(facts_registry_address);
 }
+
+#[test]
+fn config_set_chain_id_ok() {
+    let mock = deploy_mock();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+    assert(mock.get_chain_id() == 0, 'expect default 0');
+
+    mock.set_chain_id('KATANA');
+    assert(mock.get_chain_id() == 'KATANA', 'expect chain id set');
+}
+
+#[test]
+#[should_panic(expected: ('Config: not owner or operator',))]
+fn config_set_chain_id_unauthorized() {
+    let mock = deploy_mock();
+    snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
+    mock.set_chain_id('KATANA');
+}
+
+#[test]
+fn config_set_fee_token_address_ok() {
+    let mock = deploy_mock();
+    let fee_token: starknet::ContractAddress = '0xabc'.try_into().unwrap();
+
+    snf::start_cheat_caller_address(mock.contract_address, c::OWNER);
+    assert(mock.get_fee_token_address() == 0.try_into().unwrap(), 'expect default 0');
+
+    mock.set_fee_token_address(fee_token);
+    assert(mock.get_fee_token_address() == fee_token, 'expect fee token set');
+}
+
+#[test]
+#[should_panic(expected: ('Config: not owner or operator',))]
+fn config_set_fee_token_address_unauthorized() {
+    let mock = deploy_mock();
+    let fee_token: starknet::ContractAddress = '0xabc'.try_into().unwrap();
+    snf::start_cheat_caller_address(mock.contract_address, c::OTHER);
+    mock.set_fee_token_address(fee_token);
+}

--- a/src/input/component.cairo
+++ b/src/input/component.cairo
@@ -8,7 +8,7 @@ use core::poseidon::poseidon_hash_span;
 use integrity::Integrity;
 use piltover::input::snos_output::{MessageToAppchain, MessageToStarknet};
 use starknet::ContractAddress;
-use crate::config::ProgramInfo;
+use crate::config::{KatanaTeeProgramInfo, ProgramInfo, StarknetOsProgramInfo};
 use super::katana_tee_config::{KATANA_TEE_APPCHAIN_MODE, KATANA_TEE_REPORT_VERSION};
 use super::layout_bridge::{DaLayerInfo, StateUpdateInput, deserialize_layout_bridge_output};
 use super::tee_input::TEEInput;
@@ -29,6 +29,8 @@ mod errors {
     pub const TEE_CONFIG_HASH_HALF_MISMATCH: felt252 = 'tee: config hash half mismatch';
     pub const TEE_INVALID_MESSAGES: felt252 = 'tee: invalid messages';
     pub const TEE_SP1_PROOF_FAILED: felt252 = 'tee: sp1 proof failed';
+    pub const MODE_MISMATCH_LB_REQUIRES_SNOS: felt252 = 'mode: lb needs StarknetOs cfg';
+    pub const MODE_MISMATCH_TEE_REQUIRES_KATANA_TEE: felt252 = 'mode: tee needs KatanaTee cfg';
 }
 
 /// The minimum security bits required for a fact to be considered valid.
@@ -56,27 +58,37 @@ fn lb_output_to_state_update_input(lb_output: Span<felt252>) -> StateUpdateInput
 fn validate_lb_output(
     lb_output: Span<felt252>, program_info: ProgramInfo, fact_registry_address: ContractAddress,
 ) -> bool {
+    let StarknetOsProgramInfo {
+        bootloader_program_hash, snos_config_hash, snos_program_hash, layout_bridge_program_hash,
+    } =
+        match program_info {
+            ProgramInfo::StarknetOs(info) => info,
+            ProgramInfo::KatanaTee(_) => core::panic_with_felt252(
+                errors::MODE_MISMATCH_LB_REQUIRES_SNOS,
+            ),
+        };
+
     let lb = deserialize_layout_bridge_output(lb_output);
     assert(
-        program_info.snos_program_hash == lb.bootloader_output.snos_program_hash,
+        snos_program_hash == lb.bootloader_output.snos_program_hash,
         errors::SNOS_INVALID_PROGRAM_HASH,
     );
     assert(
-        program_info.layout_bridge_program_hash == lb.layout_bridge_program_hash,
+        layout_bridge_program_hash == lb.layout_bridge_program_hash,
         errors::LAYOUT_BRIDGE_INVALID_PROGRAM_HASH,
     );
     assert(
-        program_info.bootloader_program_hash == lb.bootloader_program_hash,
+        bootloader_program_hash == lb.bootloader_program_hash,
         errors::LAYOUT_BRIDGE_INVALID_BOOTLOADER_HASH,
     );
     let program_output_struct = lb.bootloader_output.snos_output;
     assert(
-        program_output_struct.starknet_os_config_hash == program_info.snos_config_hash,
+        program_output_struct.starknet_os_config_hash == snos_config_hash,
         errors::SNOS_INVALID_CONFIG_HASH,
     );
 
     let output_hash = poseidon_hash_span(lb_output);
-    let fact = poseidon_hash_span(array![program_info.bootloader_program_hash, output_hash].span());
+    let fact = poseidon_hash_span(array![bootloader_program_hash, output_hash].span());
     let integrity = Integrity::from_address(fact_registry_address);
     assert(
         integrity.is_fact_hash_valid_with_security(fact, MIN_SECURITY_BITS),
@@ -99,18 +111,19 @@ pub trait PiltoverInputTrait {
     }
     /// Validates the input based on its type.
     ///
-    /// For `LayoutBridgeOutput*` variants, `fact_registry_address` must point to an Integrity
-    /// fact registry contract, and `program_info` is used to verify program hashes.
-    /// `expected_katana_tee_config_hash` is unused on these variants.
+    /// The `PiltoverInput` variant must agree with the active `ProgramInfo` variant:
+    /// `LayoutBridgeOutput*` requires `ProgramInfo::StarknetOs`, `TeeInput` requires
+    /// `ProgramInfo::KatanaTee`. Cross-variant submission panics.
     ///
-    /// For `TeeInput`, `fact_registry_address` must point to an `IAMDTeeRegistry` contract
-    /// and `expected_katana_tee_config_hash` must be the v1 config hash recomputed from
-    /// the Piltover config (chain id + fee token). `program_info` is unused on this variant.
+    /// For `LayoutBridgeOutput*`, `fact_registry_address` must point to an Integrity
+    /// fact registry, and the `StarknetOs` program hashes are verified against the
+    /// bootloaded SNOS output.
+    ///
+    /// For `TeeInput`, `fact_registry_address` must point to an `IAMDTeeRegistry`
+    /// contract; the attested config hash is checked against the `KatanaTee` variant's
+    /// stored hash.
     fn validate_input(
-        self: @PiltoverInput,
-        program_info: ProgramInfo,
-        fact_registry_address: ContractAddress,
-        expected_katana_tee_config_hash: felt252,
+        self: @PiltoverInput, program_info: ProgramInfo, fact_registry_address: ContractAddress,
     ) -> bool {
         match self {
             PiltoverInput::LayoutBridgeOutputNoDa(lb_output) => {
@@ -120,11 +133,21 @@ pub trait PiltoverInputTrait {
                 lb_output, _,
             )) => { validate_lb_output(*lb_output, program_info, fact_registry_address) },
             PiltoverInput::TeeInput(tee_input) => {
+                let KatanaTeeProgramInfo {
+                    katana_tee_config_hash,
+                } =
+                    match program_info {
+                        ProgramInfo::KatanaTee(info) => info,
+                        ProgramInfo::StarknetOs(_) => core::panic_with_felt252(
+                            errors::MODE_MISMATCH_TEE_REQUIRES_KATANA_TEE,
+                        ),
+                    };
+
                 // 1. Environment binding: the attested config hash must match the
-                //    Piltover-side expected hash (recomputed from chain id + fee token).
-                //    Rejects attestations from any other appchain configuration.
+                //    Piltover-stored hash. Rejects attestations from any other
+                //    appchain configuration.
                 assert!(
-                    *tee_input.katana_tee_config_hash == expected_katana_tee_config_hash,
+                    *tee_input.katana_tee_config_hash == katana_tee_config_hash,
                     "{}",
                     errors::TEE_INVALID_CONFIG_HASH,
                 );

--- a/src/input/component.cairo
+++ b/src/input/component.cairo
@@ -9,6 +9,7 @@ use integrity::Integrity;
 use piltover::input::snos_output::{MessageToAppchain, MessageToStarknet};
 use starknet::ContractAddress;
 use crate::config::ProgramInfo;
+use super::katana_tee_config::{KATANA_TEE_APPCHAIN_MODE, KATANA_TEE_REPORT_VERSION};
 use super::layout_bridge::{DaLayerInfo, StateUpdateInput, deserialize_layout_bridge_output};
 use super::tee_input::TEEInput;
 
@@ -23,6 +24,11 @@ mod errors {
     pub const NO_FACT_REGISTERED: felt252 = 'no fact registered';
     pub const LAYOUT_BRIDGE_INVALID_PROGRAM_HASH: felt252 = 'lb: invalid program hash';
     pub const LAYOUT_BRIDGE_INVALID_BOOTLOADER_HASH: felt252 = 'lb: invalid bootloader hash';
+    pub const TEE_INVALID_CONFIG_HASH: felt252 = 'tee: invalid config hash';
+    pub const TEE_REPORT_DATA_MISMATCH: felt252 = 'tee: report data mismatch';
+    pub const TEE_CONFIG_HASH_HALF_MISMATCH: felt252 = 'tee: config hash half mismatch';
+    pub const TEE_INVALID_MESSAGES: felt252 = 'tee: invalid messages';
+    pub const TEE_SP1_PROOF_FAILED: felt252 = 'tee: sp1 proof failed';
 }
 
 /// The minimum security bits required for a fact to be considered valid.
@@ -95,12 +101,16 @@ pub trait PiltoverInputTrait {
     ///
     /// For `LayoutBridgeOutput*` variants, `fact_registry_address` must point to an Integrity
     /// fact registry contract, and `program_info` is used to verify program hashes.
+    /// `expected_katana_tee_config_hash` is unused on these variants.
     ///
     /// For `TeeInput`, `fact_registry_address` must point to an `IAMDTeeRegistry` contract
-    /// instead. `program_info` is not used — TEE validation is based solely on the SP1 proof
-    /// and the AMD attestation report embedded in its journal.
+    /// and `expected_katana_tee_config_hash` must be the v1 config hash recomputed from
+    /// the Piltover config (chain id + fee token). `program_info` is unused on this variant.
     fn validate_input(
-        self: @PiltoverInput, program_info: ProgramInfo, fact_registry_address: ContractAddress,
+        self: @PiltoverInput,
+        program_info: ProgramInfo,
+        fact_registry_address: ContractAddress,
+        expected_katana_tee_config_hash: felt252,
     ) -> bool {
         match self {
             PiltoverInput::LayoutBridgeOutputNoDa(lb_output) => {
@@ -110,9 +120,16 @@ pub trait PiltoverInputTrait {
                 lb_output, _,
             )) => { validate_lb_output(*lb_output, program_info, fact_registry_address) },
             PiltoverInput::TeeInput(tee_input) => {
-                // For TEE, fact_registry_address must be the IAMDTeeRegistry contract.
-                // The SP1 proof is submitted to it for verification; the registry returns a
-                // journal containing the AMD attestation report and a verification result.
+                // 1. Environment binding: the attested config hash must match the
+                //    Piltover-side expected hash (recomputed from chain id + fee token).
+                //    Rejects attestations from any other appchain configuration.
+                assert!(
+                    *tee_input.katana_tee_config_hash == expected_katana_tee_config_hash,
+                    "{}",
+                    errors::TEE_INVALID_CONFIG_HASH,
+                );
+
+                // 2. SP1 proof verification + raw report extraction.
                 let registry = IAMDTeeRegistryDispatcher {
                     contract_address: fact_registry_address,
                 };
@@ -120,32 +137,61 @@ pub trait PiltoverInputTrait {
                 let journal = registry.verify_sp1_proof(sp1_proof.into()).unwrap();
                 let raw_report = RawAttestationReport { raw: journal.raw_report };
                 let report_data = raw_report.report_data();
-                // report_data is a 256-bit field split across four u64 limbs (limb0..limb3).
-                // The commitment is a felt252 (< 252 bits), so the upper two limbs must be zero.
-                assert!(report_data.limb2 == 0);
-                assert!(report_data.limb3 == 0);
-                // The TEE attests to a commitment of (block_number, block_hash, state_root).
-                // The report_data bytes are big-endian, so limb0 is the most-significant chunk;
-                // each limb is byte-reversed to convert from big-endian to little-endian felt252.
-                let expected_commitment = u256 {
+
+                // 3. Decode `report_data` (u512) as two big-endian 32-byte halves.
+                //    First half = v1 commitment (felt252).
+                //    Second half = config hash (felt252), exposed for direct inspection.
+                //    Each 32-byte half is two u128 limbs in big-endian order; byte-reversing
+                //    each limb converts to little-endian for u256 / felt252 comparison.
+                let attested_commitment = u256 {
                     low: u128_byte_reverse(report_data.limb1),
                     high: u128_byte_reverse(report_data.limb0),
                 };
+                let attested_config_hash = u256 {
+                    low: u128_byte_reverse(report_data.limb3),
+                    high: u128_byte_reverse(report_data.limb2),
+                };
+
+                // 4. Second-half config hash must equal the input config hash.
+                //    Catches the failure mode where someone attests to a different config
+                //    in the second half but constructs a matching first-half commitment.
+                assert!(
+                    attested_config_hash == (*tee_input.katana_tee_config_hash).into(),
+                    "{}",
+                    errors::TEE_CONFIG_HASH_HALF_MISMATCH,
+                );
+
+                // 5. Recompute the v1 commitment from the input fields and assert it matches
+                //    the attested first half. v1 schema:
+                //      Poseidon([
+                //        KATANA_TEE_REPORT_VERSION,
+                //        KATANA_TEE_APPCHAIN_MODE,
+                //        prev_state_root, state_root,
+                //        prev_block_hash, block_hash,
+                //        prev_block_number, block_number,
+                //        messages_commitment,
+                //        katana_tee_config_hash,
+                //      ])
                 let commitment = poseidon_hash_span(
                     array![
+                        KATANA_TEE_REPORT_VERSION, KATANA_TEE_APPCHAIN_MODE,
                         *tee_input.prev_state_root, *tee_input.state_root,
                         *tee_input.prev_block_hash, *tee_input.block_hash,
                         *tee_input.prev_block_number, *tee_input.block_number,
-                        *tee_input.messages_commitment,
+                        *tee_input.messages_commitment, *tee_input.katana_tee_config_hash,
                     ]
                         .span(),
                 );
-                assert!(expected_commitment == commitment.into());
+                assert!(
+                    attested_commitment == commitment.into(),
+                    "{}",
+                    errors::TEE_REPORT_DATA_MISMATCH,
+                );
 
-                assert!(journal.result == Success);
+                assert!(journal.result == Success, "{}", errors::TEE_SP1_PROOF_FAILED);
 
-                // Verify messages_commitment matches the provided message data.
-                // l2_to_l1: recompute Poseidon hash for each MessageToStarknet.
+                // 6. Verify messages_commitment matches the provided message data.
+                //    l2_to_l1: recompute Poseidon hash for each MessageToStarknet.
                 let mut l2_to_l1_hashes: Array<felt252> = array![];
                 for msg in *tee_input.messages_to_starknet {
                     let payload_hash = poseidon_hash_span(
@@ -173,7 +219,11 @@ pub trait PiltoverInputTrait {
                 let expected_messages_commitment = poseidon_hash_span(
                     array![l2_to_l1_commitment, l1_to_l2_commitment].span(),
                 );
-                assert!(expected_messages_commitment == *tee_input.messages_commitment);
+                assert!(
+                    expected_messages_commitment == *tee_input.messages_commitment,
+                    "{}",
+                    errors::TEE_INVALID_MESSAGES,
+                );
 
                 true
             },

--- a/src/input/katana_tee_config.cairo
+++ b/src/input/katana_tee_config.cairo
@@ -1,0 +1,97 @@
+//! SPDX-License-Identifier: MIT
+//!
+//! Versioned config-hash and report-data tags for Katana TEE attestations.
+//!
+//! These mirror the Rust constants in
+//! `katana_rpc_api::tee` (`KATANA_TEE_CONFIG_VERSION`, `KATANA_TEE_REPORT_VERSION`,
+//! `KATANA_TEE_APPCHAIN_MODE`) so the on-chain v1 commitment matches the off-chain
+//! one byte-for-byte.
+
+use core::pedersen::pedersen;
+use starknet::ContractAddress;
+
+/// Domain tag for the Katana TEE environment config hash.
+pub const KATANA_TEE_CONFIG_VERSION: felt252 = 'KatanaTeeConfig1';
+
+/// Domain tag for the v1 Katana TEE report-data schema.
+pub const KATANA_TEE_REPORT_VERSION: felt252 = 'KatanaTeeReport1';
+
+/// Mode tag for appchain settlement attestations.
+pub const KATANA_TEE_APPCHAIN_MODE: felt252 = 'KatanaTeeAppchain';
+
+/// Computes the Starknet-OS-style config hash bound into v1 TEE report data.
+///
+/// `pedersen_array([KATANA_TEE_CONFIG_VERSION, chain_id, fee_token_address])`
+///
+/// The chained-Pedersen-with-length-suffix construction matches Cairo's
+/// `compute_hash_on_elements` and Rust's `Pedersen::hash_array`, so the value
+/// produced here is identical to the one Katana RPC binds into `report_data`
+/// at quote-generation time.
+pub fn compute_katana_tee_config_hash(
+    chain_id: felt252, fee_token_address: ContractAddress,
+) -> felt252 {
+    let fee_token: felt252 = fee_token_address.into();
+    pedersen_hash_on_elements(array![KATANA_TEE_CONFIG_VERSION, chain_id, fee_token].span())
+}
+
+/// Cairo equivalent of cairo-lang's `compute_hash_on_elements`: chained Pedersen
+/// with a length suffix. Equivalent to Rust's `Pedersen::hash_array`.
+fn pedersen_hash_on_elements(elements: Span<felt252>) -> felt252 {
+    let mut state: felt252 = 0;
+    let len: felt252 = elements.len().into();
+    for el in elements {
+        state = pedersen(state, *el);
+    }
+    pedersen(state, len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KATANA_TEE_CONFIG_VERSION, compute_katana_tee_config_hash, pedersen_hash_on_elements};
+
+    /// Sanity-checks the `pedersen_hash_on_elements` chain against a known-good
+    /// vector from upstream Starknet OS: hashing
+    /// `[StarknetOsConfig3, MAINNET, STRK_FEE_TOKEN]` produces the public mainnet
+    /// `starknet_os_config_hash`. Same hash function as `compute_katana_tee_config_hash`.
+    #[test]
+    fn pedersen_hash_on_elements_matches_mainnet_starknet_os_config_hash() {
+        let starknet_os_config_v3: felt252 = 'StarknetOsConfig3';
+        let mainnet_chain_id: felt252 = 0x534e5f4d41494e; // "SN_MAIN"
+        let strk_fee_token: felt252 =
+            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
+        let expected: felt252 =
+            0x70c7b342f93155315d1cb2da7a4e13a3c2430f51fb5696c1b224c3da5508dfb;
+        let computed = pedersen_hash_on_elements(
+            array![starknet_os_config_v3, mainnet_chain_id, strk_fee_token].span(),
+        );
+        assert!(computed == expected);
+    }
+
+    /// `compute_katana_tee_config_hash` is deterministic and depends on both inputs.
+    #[test]
+    fn compute_katana_tee_config_hash_is_deterministic_and_input_dependent() {
+        let chain_id: felt252 = 'KATANA';
+        let fee_token: starknet::ContractAddress =
+            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d.try_into().unwrap();
+
+        let h1 = compute_katana_tee_config_hash(chain_id, fee_token);
+        let h2 = compute_katana_tee_config_hash(chain_id, fee_token);
+        assert!(h1 == h2);
+        assert!(h1 != 0);
+
+        // Different chain_id must produce a different hash.
+        let h_other_chain = compute_katana_tee_config_hash('SN_SEPOLIA', fee_token);
+        assert!(h1 != h_other_chain);
+
+        // Different fee_token must produce a different hash.
+        let other_fee_token: starknet::ContractAddress = 0xdead.try_into().unwrap();
+        let h_other_fee = compute_katana_tee_config_hash(chain_id, other_fee_token);
+        assert!(h1 != h_other_fee);
+
+        // Version tag is bound: hashing without it must differ.
+        let fee_token_felt: felt252 = fee_token.into();
+        let h_no_version = pedersen_hash_on_elements(array![chain_id, fee_token_felt].span());
+        assert!(h1 != h_no_version);
+        let _ = KATANA_TEE_CONFIG_VERSION; // keep constant referenced
+    }
+}

--- a/src/input/katana_tee_config.cairo
+++ b/src/input/katana_tee_config.cairo
@@ -1,97 +1,19 @@
 //! SPDX-License-Identifier: MIT
 //!
-//! Versioned config-hash and report-data tags for Katana TEE attestations.
+//! Versioned report-data tags for Katana TEE attestations.
 //!
-//! These mirror the Rust constants in
-//! `katana_rpc_api::tee` (`KATANA_TEE_CONFIG_VERSION`, `KATANA_TEE_REPORT_VERSION`,
-//! `KATANA_TEE_APPCHAIN_MODE`) so the on-chain v1 commitment matches the off-chain
-//! one byte-for-byte.
-
-use core::pedersen::pedersen;
-use starknet::ContractAddress;
-
-/// Domain tag for the Katana TEE environment config hash.
-pub const KATANA_TEE_CONFIG_VERSION: felt252 = 'KatanaTeeConfig1';
+//! These mirror the Rust constants in `katana_rpc_api::tee`
+//! (`KATANA_TEE_REPORT_VERSION`, `KATANA_TEE_APPCHAIN_MODE`) so the on-chain v1
+//! commitment matches the off-chain one byte-for-byte.
+//!
+//! The config hash itself (`KatanaTeeConfig1`-tagged Pedersen-array hash of
+//! `[chain_id, fee_token_address]`) is computed off-chain by Katana RPC and
+//! stored on-chain in `KatanaTeeProgramInfo.katana_tee_config_hash`. The
+//! on-chain side stores and compares but does not recompute, so no `KatanaTeeConfig1`
+//! tag is needed here.
 
 /// Domain tag for the v1 Katana TEE report-data schema.
 pub const KATANA_TEE_REPORT_VERSION: felt252 = 'KatanaTeeReport1';
 
 /// Mode tag for appchain settlement attestations.
 pub const KATANA_TEE_APPCHAIN_MODE: felt252 = 'KatanaTeeAppchain';
-
-/// Computes the Starknet-OS-style config hash bound into v1 TEE report data.
-///
-/// `pedersen_array([KATANA_TEE_CONFIG_VERSION, chain_id, fee_token_address])`
-///
-/// The chained-Pedersen-with-length-suffix construction matches Cairo's
-/// `compute_hash_on_elements` and Rust's `Pedersen::hash_array`, so the value
-/// produced here is identical to the one Katana RPC binds into `report_data`
-/// at quote-generation time.
-pub fn compute_katana_tee_config_hash(
-    chain_id: felt252, fee_token_address: ContractAddress,
-) -> felt252 {
-    let fee_token: felt252 = fee_token_address.into();
-    pedersen_hash_on_elements(array![KATANA_TEE_CONFIG_VERSION, chain_id, fee_token].span())
-}
-
-/// Cairo equivalent of cairo-lang's `compute_hash_on_elements`: chained Pedersen
-/// with a length suffix. Equivalent to Rust's `Pedersen::hash_array`.
-fn pedersen_hash_on_elements(elements: Span<felt252>) -> felt252 {
-    let mut state: felt252 = 0;
-    let len: felt252 = elements.len().into();
-    for el in elements {
-        state = pedersen(state, *el);
-    }
-    pedersen(state, len)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{KATANA_TEE_CONFIG_VERSION, compute_katana_tee_config_hash, pedersen_hash_on_elements};
-
-    /// Sanity-checks the `pedersen_hash_on_elements` chain against a known-good
-    /// vector from upstream Starknet OS: hashing
-    /// `[StarknetOsConfig3, MAINNET, STRK_FEE_TOKEN]` produces the public mainnet
-    /// `starknet_os_config_hash`. Same hash function as `compute_katana_tee_config_hash`.
-    #[test]
-    fn pedersen_hash_on_elements_matches_mainnet_starknet_os_config_hash() {
-        let starknet_os_config_v3: felt252 = 'StarknetOsConfig3';
-        let mainnet_chain_id: felt252 = 0x534e5f4d41494e; // "SN_MAIN"
-        let strk_fee_token: felt252 =
-            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
-        let expected: felt252 =
-            0x70c7b342f93155315d1cb2da7a4e13a3c2430f51fb5696c1b224c3da5508dfb;
-        let computed = pedersen_hash_on_elements(
-            array![starknet_os_config_v3, mainnet_chain_id, strk_fee_token].span(),
-        );
-        assert!(computed == expected);
-    }
-
-    /// `compute_katana_tee_config_hash` is deterministic and depends on both inputs.
-    #[test]
-    fn compute_katana_tee_config_hash_is_deterministic_and_input_dependent() {
-        let chain_id: felt252 = 'KATANA';
-        let fee_token: starknet::ContractAddress =
-            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d.try_into().unwrap();
-
-        let h1 = compute_katana_tee_config_hash(chain_id, fee_token);
-        let h2 = compute_katana_tee_config_hash(chain_id, fee_token);
-        assert!(h1 == h2);
-        assert!(h1 != 0);
-
-        // Different chain_id must produce a different hash.
-        let h_other_chain = compute_katana_tee_config_hash('SN_SEPOLIA', fee_token);
-        assert!(h1 != h_other_chain);
-
-        // Different fee_token must produce a different hash.
-        let other_fee_token: starknet::ContractAddress = 0xdead.try_into().unwrap();
-        let h_other_fee = compute_katana_tee_config_hash(chain_id, other_fee_token);
-        assert!(h1 != h_other_fee);
-
-        // Version tag is bound: hashing without it must differ.
-        let fee_token_felt: felt252 = fee_token.into();
-        let h_no_version = pedersen_hash_on_elements(array![chain_id, fee_token_felt].span());
-        assert!(h1 != h_no_version);
-        let _ = KATANA_TEE_CONFIG_VERSION; // keep constant referenced
-    }
-}

--- a/src/input/tee_input.cairo
+++ b/src/input/tee_input.cairo
@@ -15,5 +15,10 @@ pub struct TEEInput {
     /// keccak256 hashes (as felts) of each L1→L2 message, used to reconstruct
     /// `l1_to_l2_commitment` without recomputing keccak inside the contract.
     pub l1_to_l2_msg_hashes: Span<felt252>,
+    /// Versioned environment config hash bound into the v1 `report_data`.
+    /// Recomputed on-chain from Piltover config (chain id + fee token) and
+    /// asserted to equal this field, so attestations from a different
+    /// appchain configuration are rejected.
+    pub katana_tee_config_hash: felt252,
 }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,6 +3,7 @@ pub mod fact_registry;
 pub mod interface;
 pub mod input {
     pub mod component;
+    pub mod katana_tee_config;
     pub mod layout_bridge;
     pub mod mock_amd_tee_registry;
     pub mod snos_output;

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -17,7 +17,10 @@ pub mod config {
     pub mod mock;
 
     pub use component::config_cpt;
-    pub use interface::{IConfig, IConfigDispatcher, IConfigDispatcherTrait, ProgramInfo};
+    pub use interface::{
+        IConfig, IConfigDispatcher, IConfigDispatcherTrait, KatanaTeeProgramInfo, ProgramInfo,
+        StarknetOsProgramInfo,
+    };
     pub use mock::config_mock;
 
     #[cfg(target: 'test')]

--- a/tests/test_appchain.cairo
+++ b/tests/test_appchain.cairo
@@ -7,7 +7,10 @@ use piltover::appchain::appchain::{Event, LogStateTransitionFact, LogStateUpdate
 //! Appchain testing.
 //!
 use piltover::config::tests::constants as c;
-use piltover::config::{IConfigDispatcher, IConfigDispatcherTrait, ProgramInfo};
+use piltover::config::{
+    IConfigDispatcher, IConfigDispatcherTrait, KatanaTeeProgramInfo, ProgramInfo,
+    StarknetOsProgramInfo,
+};
 use piltover::fact_registry::IFactRegistryDispatcher;
 use piltover::input::snos_output::{StarknetOsOutput, deserialize_os_output};
 use piltover::interface::{IAppchainDispatcher, IAppchainDispatcherTrait};
@@ -186,14 +189,14 @@ fn appchain_owner_ok() {
     snf::start_cheat_caller_address(appchain.contract_address, c::OWNER);
     iconfig
         .set_program_info(
-            ProgramInfo {
-                bootloader_program_hash: 0x11,
-                snos_config_hash: 0x22,
-                snos_program_hash: 0x33,
-                layout_bridge_program_hash: 0x44,
-                chain_id: 'KATANA',
-                fee_token_address: 0xfee.try_into().unwrap(),
-            },
+            ProgramInfo::StarknetOs(
+                StarknetOsProgramInfo {
+                    bootloader_program_hash: 0x11,
+                    snos_config_hash: 0x22,
+                    snos_program_hash: 0x33,
+                    layout_bridge_program_hash: 0x44,
+                },
+            ),
         );
 }
 
@@ -205,14 +208,14 @@ fn appchain_owner_only() {
     let iconfig = IConfigDispatcher { contract_address: appchain.contract_address };
     iconfig
         .set_program_info(
-            ProgramInfo {
-                bootloader_program_hash: 0x11,
-                snos_config_hash: 0x22,
-                snos_program_hash: 0x33,
-                layout_bridge_program_hash: 0x44,
-                chain_id: 'KATANA',
-                fee_token_address: 0xfee.try_into().unwrap(),
-            },
+            ProgramInfo::StarknetOs(
+                StarknetOsProgramInfo {
+                    bootloader_program_hash: 0x11,
+                    snos_config_hash: 0x22,
+                    snos_program_hash: 0x33,
+                    layout_bridge_program_hash: 0x44,
+                },
+            ),
         );
 }
 
@@ -254,23 +257,25 @@ fn setup_for_update_state(
     (appchain, imsg)
 }
 
-fn correct_program_info() -> ProgramInfo {
-    ProgramInfo {
+fn correct_starknet_os_program_info() -> StarknetOsProgramInfo {
+    StarknetOsProgramInfo {
         bootloader_program_hash: 'bootloader_hash',
         snos_config_hash: 8868593919264901768958912247765226517850727970326290266005120699201631282,
         snos_program_hash: 'snos_hash',
         layout_bridge_program_hash: 'layout_bridge_hash',
-        chain_id: 'KATANA',
-        fee_token_address: 0xfee.try_into().unwrap(),
     }
+}
+
+fn correct_program_info() -> ProgramInfo {
+    ProgramInfo::StarknetOs(correct_starknet_os_program_info())
 }
 
 #[test]
 #[should_panic(expected: ('snos: invalid program hash',))]
 fn update_state_invalid_snos_program_hash() {
-    let mut info = correct_program_info();
+    let mut info = correct_starknet_os_program_info();
     info.snos_program_hash = 'wrong_snos_hash';
-    let (appchain, _) = setup_for_update_state(info);
+    let (appchain, _) = setup_for_update_state(ProgramInfo::StarknetOs(info));
     let piltover_input = piltover::input::component::PiltoverInput::LayoutBridgeOutputNoDa(
         get_output(),
     );
@@ -280,9 +285,9 @@ fn update_state_invalid_snos_program_hash() {
 #[test]
 #[should_panic(expected: ('lb: invalid program hash',))]
 fn update_state_invalid_layout_bridge_hash() {
-    let mut info = correct_program_info();
+    let mut info = correct_starknet_os_program_info();
     info.layout_bridge_program_hash = 'wrong_lb_hash';
-    let (appchain, _) = setup_for_update_state(info);
+    let (appchain, _) = setup_for_update_state(ProgramInfo::StarknetOs(info));
     let piltover_input = piltover::input::component::PiltoverInput::LayoutBridgeOutputNoDa(
         get_output(),
     );
@@ -292,9 +297,9 @@ fn update_state_invalid_layout_bridge_hash() {
 #[test]
 #[should_panic(expected: ('lb: invalid bootloader hash',))]
 fn update_state_invalid_bootloader_hash() {
-    let mut info = correct_program_info();
+    let mut info = correct_starknet_os_program_info();
     info.bootloader_program_hash = 'wrong_bootloader_hash';
-    let (appchain, _) = setup_for_update_state(info);
+    let (appchain, _) = setup_for_update_state(ProgramInfo::StarknetOs(info));
     let piltover_input = piltover::input::component::PiltoverInput::LayoutBridgeOutputNoDa(
         get_output(),
     );
@@ -304,9 +309,9 @@ fn update_state_invalid_bootloader_hash() {
 #[test]
 #[should_panic(expected: ('snos: invalid config hash',))]
 fn update_state_invalid_config_hash() {
-    let mut info = correct_program_info();
+    let mut info = correct_starknet_os_program_info();
     info.snos_config_hash = 'wrong_config_hash';
-    let (appchain, _) = setup_for_update_state(info);
+    let (appchain, _) = setup_for_update_state(ProgramInfo::StarknetOs(info));
     let piltover_input = piltover::input::component::PiltoverInput::LayoutBridgeOutputNoDa(
         get_output(),
     );
@@ -368,14 +373,14 @@ fn update_state_ok() {
     snf::start_cheat_caller_address(appchain.contract_address, c::OWNER);
     iconfig
         .set_program_info(
-            ProgramInfo {
-                bootloader_program_hash: 'bootloader_hash',
-                snos_config_hash: 8868593919264901768958912247765226517850727970326290266005120699201631282,
-                snos_program_hash: 'snos_hash',
-                layout_bridge_program_hash: 'layout_bridge_hash',
-                chain_id: 'KATANA',
-                fee_token_address: 0xfee.try_into().unwrap(),
-            },
+            ProgramInfo::StarknetOs(
+                StarknetOsProgramInfo {
+                    bootloader_program_hash: 'bootloader_hash',
+                    snos_config_hash: 8868593919264901768958912247765226517850727970326290266005120699201631282,
+                    snos_program_hash: 'snos_hash',
+                    layout_bridge_program_hash: 'layout_bridge_hash',
+                },
+            ),
         );
     iconfig.set_facts_registry(address: fact_registry_mock.contract_address);
     // The state update contains a message to appchain, therefore, before
@@ -415,4 +420,58 @@ fn update_state_ok() {
         );
     snf::start_cheat_caller_address(appchain.contract_address, contract_sn);
     imsg.consume_message_from_appchain(contract_appc, payload_appc_to_sn);
+}
+
+/// Submitting a `TeeInput` against a Piltover configured for `StarknetOs` settlement
+/// must panic with the mode-mismatch error before any AMDTEERegistry call is made.
+#[test]
+#[should_panic(expected: ('mode: tee needs KatanaTee cfg',))]
+fn update_state_tee_input_with_starknet_os_config_panics() {
+    let (appchain, _spy) = deploy_with_owner_and_state(
+        owner: c::OWNER, state_root: 0, block_number: 0, block_hash: 0,
+    );
+
+    let iconfig = IConfigDispatcher { contract_address: appchain.contract_address };
+    snf::start_cheat_caller_address(appchain.contract_address, c::OWNER);
+    iconfig.set_program_info(correct_program_info());
+
+    let tee_input = piltover::input::tee_input::TEEInput {
+        sp1_proof: array![].span(),
+        prev_state_root: 0,
+        state_root: 0,
+        prev_block_hash: 0,
+        block_hash: 0,
+        prev_block_number: 0,
+        block_number: 0,
+        messages_commitment: 0,
+        messages_to_starknet: array![].span(),
+        messages_to_appchain: array![].span(),
+        l1_to_l2_msg_hashes: array![].span(),
+        katana_tee_config_hash: 0,
+    };
+    let piltover_input = piltover::input::component::PiltoverInput::TeeInput(tee_input);
+
+    appchain.update_state(piltover_input);
+}
+
+/// Submitting a `LayoutBridgeOutput` against a Piltover configured for TEE settlement
+/// must panic with the mode-mismatch error before any fact-registry call is made.
+#[test]
+#[should_panic(expected: ('mode: lb needs StarknetOs cfg',))]
+fn update_state_lb_input_with_katana_tee_config_panics() {
+    let (appchain, _spy) = deploy_with_owner_and_state(
+        owner: c::OWNER, state_root: 0, block_number: 0, block_hash: 0,
+    );
+
+    let iconfig = IConfigDispatcher { contract_address: appchain.contract_address };
+    snf::start_cheat_caller_address(appchain.contract_address, c::OWNER);
+    iconfig
+        .set_program_info(
+            ProgramInfo::KatanaTee(KatanaTeeProgramInfo { katana_tee_config_hash: 0xabc }),
+        );
+
+    let piltover_input = piltover::input::component::PiltoverInput::LayoutBridgeOutputNoDa(
+        get_output(),
+    );
+    appchain.update_state(piltover_input);
 }

--- a/tests/test_appchain.cairo
+++ b/tests/test_appchain.cairo
@@ -191,6 +191,8 @@ fn appchain_owner_ok() {
                 snos_config_hash: 0x22,
                 snos_program_hash: 0x33,
                 layout_bridge_program_hash: 0x44,
+                chain_id: 'KATANA',
+                fee_token_address: 0xfee.try_into().unwrap(),
             },
         );
 }
@@ -208,6 +210,8 @@ fn appchain_owner_only() {
                 snos_config_hash: 0x22,
                 snos_program_hash: 0x33,
                 layout_bridge_program_hash: 0x44,
+                chain_id: 'KATANA',
+                fee_token_address: 0xfee.try_into().unwrap(),
             },
         );
 }
@@ -256,6 +260,8 @@ fn correct_program_info() -> ProgramInfo {
         snos_config_hash: 8868593919264901768958912247765226517850727970326290266005120699201631282,
         snos_program_hash: 'snos_hash',
         layout_bridge_program_hash: 'layout_bridge_hash',
+        chain_id: 'KATANA',
+        fee_token_address: 0xfee.try_into().unwrap(),
     }
 }
 
@@ -367,6 +373,8 @@ fn update_state_ok() {
                 snos_config_hash: 8868593919264901768958912247765226517850727970326290266005120699201631282,
                 snos_program_hash: 'snos_hash',
                 layout_bridge_program_hash: 'layout_bridge_hash',
+                chain_id: 'KATANA',
+                fee_token_address: 0xfee.try_into().unwrap(),
             },
         );
     iconfig.set_facts_registry(address: fact_registry_mock.contract_address);


### PR DESCRIPTION
## Summary

Two changes that together pin a TEE-attested settlement to a specific appchain configuration:

1. **`ProgramInfo` becomes an enum.** Validity-proof and TEE settlement identify the appchain in genuinely different ways (four SNOS hashes vs. one versioned environment config hash), so they live in separate variants now. Each Piltover deployment commits to one mode at config time; cross-mode submission panics in `validate_input` before any registry call.

2. **TEE `report_data` is bound to a versioned environment config hash.** The `katana_tee_config_hash` (a Pedersen-array hash of `[KatanaTeeConfig1, chain_id, fee_token_address]`, computed off-chain by the Katana node) is bound into both halves of `report_data` and asserted on-chain against the value stored in `KatanaTeeProgramInfo`:

```
report_data[0..32]  = Poseidon([
                         KATANA_TEE_REPORT_VERSION,
                         KATANA_TEE_APPCHAIN_MODE,
                         prev_state_root, state_root,
                         prev_block_hash,  block_hash,
                         prev_block_number, block_number,
                         messages_commitment,
                         katana_tee_config_hash,
                     ])
report_data[32..64] = katana_tee_config_hash (raw felt252)
```

An attestation produced by a Katana node configured for a different appchain (different `chain_id` or fee token) now fails verification at settlement time rather than producing silently-wrong state.

**Companion PR:** [dojoengine/katana#556](https://github.com/dojoengine/katana/pull/556) — Katana-side computation of the same hash from the chain spec, bound into the report at quote-generation time.

## Changes

- **`src/config/interface.cairo`** — `ProgramInfo` is now an enum:
  ```
  enum ProgramInfo {
      StarknetOs(StarknetOsProgramInfo),  // 4 SNOS-related hashes
      KatanaTee(KatanaTeeProgramInfo),    // single katana_tee_config_hash
  }
  ```
  `StarknetOs` is `#[default]` so fresh storage matches the prior zero-init semantics.
- **`src/input/component.cairo`** — `validate_input` enforces the variant invariant: `LayoutBridgeOutput*` requires `StarknetOs`, `TeeInput` requires `KatanaTee`. Mismatch panics with `mode: tee needs KatanaTee cfg` / `mode: lb needs StarknetOs cfg`. The TEE arm sources the expected config hash from the active variant, drops the old `expected_katana_tee_config_hash` parameter, then performs the v1 commitment recompute + second-half decode.
- **`src/appchain.cairo`** — `update_state` simply reads `program_info` and threads it through; no on-chain hash recomputation.
- **`src/input/katana_tee_config.cairo`** — Trimmed to the two report-data tags (`KATANA_TEE_REPORT_VERSION`, `KATANA_TEE_APPCHAIN_MODE`). The config-hash computation lives entirely in Katana RPC (companion PR), since the on-chain side only stores and compares.
- **`src/input/tee_input.cairo`** — `TEEInput` carries `katana_tee_config_hash: felt252`.
- **`src/lib.cairo`** — Re-exports `StarknetOsProgramInfo` and `KatanaTeeProgramInfo`.
- **Tests** — Existing `ProgramInfo {...}` literals wrapped in `ProgramInfo::StarknetOs(...)`. New tests: variant roundtrip, plus mode-mismatch regression in both directions.

## Test plan

- [x] `scarb build` clean
- [x] `snforge test` — 57 passing (3 new vs. baseline: variant roundtrip + two mode-mismatch regressions)
- [x] LayoutBridge path tests untouched and still pass (proves the variant-extraction refactor didn't break validity-proof settlement)
- [ ] End-to-end TEE binding with real SP1 proof + SEV-SNP report — follow-up via the companion Katana PR's e2e fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)