### PR TITLE
ci: pin asdf to last shell release (v0.14.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: asdf-vm/actions/install@v3.0.2
+        with:
+          asdf_branch: v0.14.1
       - run: scarb build
 
   all_features:
@@ -21,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: asdf-vm/actions/install@v3.0.2
+        with:
+          asdf_branch: v0.14.1
       - run: scarb build --all-features
 
   rust:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: asdf-vm/actions/install@v3.0.2
+        with:
+          asdf_branch: v0.14.1
       - run: scarb fmt --check
 
   test:
@@ -31,6 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: asdf-vm/actions/install@v3.0.2
+        with:
+          asdf_branch: v0.14.1
       - run: scarb test --all-features
 
   rust_bindings:
@@ -43,6 +47,8 @@ jobs:
           toolchain: nightly-2024-08-28
           components: rustfmt
       - uses: asdf-vm/actions/install@v3.0.2
+        with:
+          asdf_branch: v0.14.1
       - name: Generate bindings
         run: bash scripts/generate_bindings.sh
       - name: Check for changes


### PR DESCRIPTION
## Summary

Unblocks CI on `feat/tee-persistent` (and any stacked PR targeting it, including [#16](https://github.com/cartridge-gg/piltover/pull/16)).

`asdf-vm/actions/install@v3.0.2` defaults to cloning `asdf-vm/asdf`'s `master` branch and expects a runnable `asdf` shell script. asdf v0.16+ rewrote the entrypoint from Bash to Go, so cloning master no longer yields an executable script. Every job that touches asdf has been failing on the same step since the upstream change shipped.

Pinning `asdf_branch: v0.14.1` (last shell release) lets the action work as-designed without rewriting the workflows. Future-proofing onto a Go-aware install action is out of scope.

## Failing jobs (all on this same step)

`build / default`, `build / all_features`, `check / fmt`, `check / test`, `check / rust_bindings` — every one fails with:

```
##[error]Action failed with error Error: Unable to locate executable file: asdf.
Please verify either the file path exists or the file can be found within
a directory specified by the PATH environment variable.
```

Latest example: https://github.com/cartridge-gg/piltover/actions/runs/25071404878

## Changes

- `.github/workflows/build.yml` — adds `with.asdf_branch: v0.14.1` to the 2 asdf-install steps
- `.github/workflows/check.yml` — adds the same to the 3 asdf-install steps

## Test plan

- [ ] CI runs on this PR succeed (proves the pin unblocks the action)
- [ ] After merge, rebase / sync PR #16 onto `feat/tee-persistent` and confirm its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)